### PR TITLE
add generic types to Result, adhere to palladio coding conventions

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor.data/src/org/palladiosimulator/analyzer/slingshot/monitor/data/entities/ProcessingTypeListener.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.data/src/org/palladiosimulator/analyzer/slingshot/monitor/data/entities/ProcessingTypeListener.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.monitor.data.entities;
 
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementUpdated;
 import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
 import org.palladiosimulator.metricspec.MetricDescription;
 import org.palladiosimulator.monitorrepository.ProcessingType;
@@ -25,7 +26,7 @@ public abstract class ProcessingTypeListener {
 		/* Do nothing in the standard implementation. */
 	}
 
-	public abstract Result onMeasurementMade(final MeasurementMade measurementMade);
+	public abstract Result<MeasurementUpdated> onMeasurementMade(final MeasurementMade measurementMade);
 
 	/**
 	 * @return the processingType

--- a/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/plugin.xml
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/plugin.xml
@@ -3,6 +3,9 @@
 <plugin>
    <extension
          point="org.palladiosimulator.analyzer.slingshot">
+      <slingshot-extension
+            module="org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator.ProcessingTypeAggregationModule">
+      </slingshot-extension>
    </extension>
 
 </plugin>

--- a/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/aggregator/AbstractMeasurementAggregator.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/aggregator/AbstractMeasurementAggregator.java
@@ -51,7 +51,7 @@ public abstract class AbstractMeasurementAggregator extends ProcessingTypeListen
 	}
 
 	@Override
-	public final Result onMeasurementMade(final MeasurementMade measurementMade) {
+	public final Result<MeasurementUpdated> onMeasurementMade(final MeasurementMade measurementMade) {
 		if (!measurementMade.getEntity().isCompatibleWith(this.getMetricDescription())
 				&& !MetricDescriptionUtility.isBaseMetricDescriptionSubsumedByMetricDescription(
 						(BaseMetricDescription) this.getMetricDescription(),

--- a/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/aggregator/MeasurementsAggregatorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/aggregator/MeasurementsAggregatorBehavior.java
@@ -16,13 +16,13 @@ import org.palladiosimulator.monitorrepository.VariableSizeAggregation;
 public class MeasurementsAggregatorBehavior implements SimulationBehaviorExtension {
 
 	@Subscribe(reified = FixedSizeAggregation.class)
-	public Result onFixedSizeAggregationVisited(final MonitorModelVisited<FixedSizeAggregation> fixedSizeAggregationVisited) {
+	public Result<ProcessingTypeRevealed> onFixedSizeAggregationVisited(final MonitorModelVisited<FixedSizeAggregation> fixedSizeAggregationVisited) {
 		return Result.of(new ProcessingTypeRevealed(fixedSizeAggregationVisited.getEntity(),
 				new FixedSizeMeasurementsAggregator(fixedSizeAggregationVisited.getEntity())));
 	}
 
 	@Subscribe(reified = VariableSizeAggregation.class)
-	public Result onVariableSizeAggregationVisited(final MonitorModelVisited<VariableSizeAggregation> variableSizeAggregationVisited) {
+	public Result<ProcessingTypeRevealed> onVariableSizeAggregationVisited(final MonitorModelVisited<VariableSizeAggregation> variableSizeAggregationVisited) {
 		return Result.of(new ProcessingTypeRevealed(variableSizeAggregationVisited.getEntity(),
 				new VariableSizeMeasurementAggregator(variableSizeAggregationVisited.getEntity())));
 	}

--- a/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.feedthrough/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/feedthrough/FeedThroughRecorder.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.feedthrough/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/feedthrough/FeedThroughRecorder.java
@@ -25,7 +25,7 @@ public final class FeedThroughRecorder extends ProcessingTypeListener {
 	}
 
 	@Override
-	public Result onMeasurementMade(final MeasurementMade measurementMade) {
+	public Result<MeasurementUpdated> onMeasurementMade(final MeasurementMade measurementMade) {
 		return Result.of(new MeasurementUpdated(
 				new MeasurementUpdateInformation(measurementMade.getEntity(), this.getProcessingType(),
 						this.getMeasuringPoint())));

--- a/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.feedthrough/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/feedthrough/FeedThroughRecorderBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.feedthrough/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/feedthrough/FeedThroughRecorderBehavior.java
@@ -13,7 +13,7 @@ import org.palladiosimulator.monitorrepository.FeedThrough;
 public class FeedThroughRecorderBehavior implements SimulationBehaviorExtension {
 
 	@Subscribe(reified = FeedThrough.class)
-	public Result onFeedThroughProcessingTypeVisited(final MonitorModelVisited<FeedThrough> feedThroughEvent) {
+	public Result<ProcessingTypeRevealed> onFeedThroughProcessingTypeVisited(final MonitorModelVisited<FeedThrough> feedThroughEvent) {
 		return Result.of(new ProcessingTypeRevealed(feedThroughEvent.getEntity(),
 				new FeedThroughRecorder(feedThroughEvent.getEntity())));
 	}

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/DeferredCalculatorMeasurementInitializationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/DeferredCalculatorMeasurementInitializationBehavior.java
@@ -14,7 +14,6 @@ import org.palladiosimulator.analyzer.slingshot.core.api.SimulationScheduling;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.OnEvent;
-import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.CalculatorRegistered;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.ProcessingTypeRevealed;
 import org.palladiosimulator.analyzer.slingshot.monitor.utils.SlingshotCalculatorWrapper;
@@ -36,7 +35,7 @@ import com.google.common.base.Supplier;
  * In that way, ProcessingTypes and Calculators are decoupled and can be
  * constructed on their own, and as soon as both appropriate instances are
  * available, they will be connected.
- * 
+ *
  * @author Julijan Katic
  */
 @OnEvent(when = CalculatorRegistered.class, then = {})
@@ -109,7 +108,7 @@ public class DeferredCalculatorMeasurementInitializationBehavior implements Simu
 	 * Checks whether the metric description is subsumed by the calculator's metric
 	 * description, and if so, initializes the measurement source listeners and adds
 	 * them to the calculator.
-	 * 
+	 *
 	 * @param metricDescription The metric description to check.
 	 * @param calculator        The calculator, in which the measurement source
 	 *                          listener is possibly added.
@@ -133,7 +132,7 @@ public class DeferredCalculatorMeasurementInitializationBehavior implements Simu
 	/**
 	 * Returns whether the first metric description is the same as or subsumes the
 	 * second metric description.
-	 * 
+	 *
 	 * @return true iff the first is the same as or subsumes the second metric
 	 *         description.
 	 */
@@ -150,7 +149,7 @@ public class DeferredCalculatorMeasurementInitializationBehavior implements Simu
 	 * description and the measuring point. If the metric description is a
 	 * {@link BaseMetricDescription}, then the subsumed metric descriptions are also
 	 * checked and the first calculator to be found is returned.
-	 * 
+	 *
 	 * @param metricDescription The metric description.
 	 * @param mp                The measuring point.
 	 * @return An optional calculator that matches either the exact metric

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/ProcessingTypeMeasurementSourceListener.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/ProcessingTypeMeasurementSourceListener.java
@@ -7,6 +7,7 @@ import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.SlingshotM
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MeasurementMade;
 import org.palladiosimulator.measurementframework.MeasuringValue;
 import org.palladiosimulator.measurementframework.listener.IMeasurementSourceListener;
+import org.palladiosimulator.monitorrepository.ProcessingType;
 
 /**
  * A ProcessingTypeMeasurementSourceListener is a wrapper that delegates a
@@ -28,7 +29,7 @@ import org.palladiosimulator.measurementframework.listener.IMeasurementSourceLis
  * {@link IMeasurementSourceListener}, call the delegate and simply publish the
  * returned events from
  * {@link ProcessingTypeListener#onMeasurementMade(MeasurementMade)}.
- * 
+ *
  * @author Julijan Katic
  *
  */
@@ -42,10 +43,10 @@ public final class ProcessingTypeMeasurementSourceListener implements IMeasureme
 
 	/** The scheduling which is needed to publish events from the outside. */
 	private final SimulationScheduling scheduling;
-	
+
 	/**
 	 * Constructs a ProcessingTypeMeasurementSourceListener.
-	 * 
+	 *
 	 * @param scheduling The scheduling which is needed to publish events from the
 	 *                   outside.
 	 * @param delegate   The delegate which is like a IMeasurementSourceListener in
@@ -64,11 +65,11 @@ public final class ProcessingTypeMeasurementSourceListener implements IMeasureme
 	 * publishes each event into the event system.
 	 */
 	@Override
-	public void newMeasurementAvailable(MeasuringValue newMeasurement) {
+	public void newMeasurementAvailable(final MeasuringValue newMeasurement) {
 		if (!(newMeasurement instanceof SlingshotMeasuringValue)) {
 			throw new IllegalArgumentException("MeasuringValue must carry a measuring point!");
 		}
-		
+
 		final SlingshotMeasuringValue measuringValue = (SlingshotMeasuringValue) newMeasurement;
 		this.delegate.onMeasurementMade(new MeasurementMade(measuringValue))
 			.getResultEvents()

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorModelVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorModelVisitor.java
@@ -9,7 +9,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MonitoringEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MeasurementSpecificationVisited;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MonitorModelVisited;
-import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.ProcessingTypeVisited;
 import org.palladiosimulator.monitorrepository.ArithmeticMean;
 import org.palladiosimulator.monitorrepository.MeasurementSpecification;
 import org.palladiosimulator.monitorrepository.Monitor;
@@ -21,54 +20,54 @@ import org.palladiosimulator.monitorrepository.util.MonitorRepositorySwitch;
 public class MonitorModelVisitor extends MonitorRepositorySwitch<Set<MonitoringEvent>> {
 
 	@Override
-	public Set<MonitoringEvent> caseArithmeticMean(ArithmeticMean object) {
+	public Set<MonitoringEvent> caseArithmeticMean(final ArithmeticMean object) {
 		// TODO Auto-generated method stub
 		return super.caseArithmeticMean(object);
 	}
 
 	@Override
-	public Set<MonitoringEvent> caseMonitor(Monitor object) {
+	public Set<MonitoringEvent> caseMonitor(final Monitor object) {
 		final int numberMeasurementSpecs = object.getMeasurementSpecifications().size();
-		
+
 		final Set<MonitoringEvent> result = new HashSet<>(numberMeasurementSpecs);
-		
+
 		object.getMeasurementSpecifications().stream()
 			  .flatMap(spec -> this.doSwitch(spec).stream())
 			  .forEach(result::add);
-		
+
 		return result;
 	}
 
 	@Override
-	public Set<MonitoringEvent> caseMonitorRepository(MonitorRepository object) {
+	public Set<MonitoringEvent> caseMonitorRepository(final MonitorRepository object) {
 		return object.getMonitors().stream()
 				.flatMap(monitor -> this.doSwitch(monitor).stream())
 				.collect(Collectors.toSet());
 	}
-	
+
 	@Override
-	public Set<MonitoringEvent> caseMeasurementSpecification(MeasurementSpecification object) {
+	public Set<MonitoringEvent> caseMeasurementSpecification(final MeasurementSpecification object) {
 		final Set<MonitoringEvent> events = new HashSet<>(2);
-		
+
 		events.addAll(this.doSwitch(object.getProcessingType()));
 		events.add(new MeasurementSpecificationVisited(object));
-		
+
 		return events;
 	}
 
 	@Override
-	public Set<MonitoringEvent> caseProcessingType(ProcessingType object) {
+	public Set<MonitoringEvent> caseProcessingType(final ProcessingType object) {
 		return Set.of(new MonitorModelVisited<>(object));
 	}
 
 	@Override
-	public Set<MonitoringEvent> caseStatisticalCharacterization(StatisticalCharacterization object) {
+	public Set<MonitoringEvent> caseStatisticalCharacterization(final StatisticalCharacterization object) {
 		// TODO Auto-generated method stub
 		return super.caseStatisticalCharacterization(object);
 	}
 
 	@Override
-	public Set<MonitoringEvent> doSwitch(EObject eObject) {
+	public Set<MonitoringEvent> doSwitch(final EObject eObject) {
 		final Set<MonitoringEvent> result = super.doSwitch(eObject);
 		if (result == null) {
 			return Collections.emptySet();
@@ -77,6 +76,6 @@ public class MonitorModelVisitor extends MonitorRepositorySwitch<Set<MonitoringE
 		}
 	}
 
-	
-	
+
+
 }

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorRepositoryInterpreterBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorRepositoryInterpreterBehavior.java
@@ -8,6 +8,7 @@ import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscrib
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.OnEvent;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MonitoringEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MonitorModelVisited;
 import org.palladiosimulator.monitorrepository.MonitorRepository;
 
@@ -15,16 +16,16 @@ import org.palladiosimulator.monitorrepository.MonitorRepository;
 public class MonitorRepositoryInterpreterBehavior implements SimulationBehaviorExtension {
 
 	private final MonitorRepository monitorRepository;
-	
+
 	@Inject
 	public MonitorRepositoryInterpreterBehavior(final MonitorRepository monitorRepository) {
 		this.monitorRepository = monitorRepository;
 	}
-	
+
 	@Subscribe
-	public Result onPreSimulationConfigurationStarted(final PreSimulationConfigurationStarted event) {
+	public Result<MonitoringEvent> onPreSimulationConfigurationStarted(final PreSimulationConfigurationStarted event) {
 		final MonitorModelVisitor visitor = new MonitorModelVisitor();
 		return Result.from(visitor.doSwitch(monitorRepository));
 	}
-	
+
 }

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/ui/MonitorRepositoryProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/ui/MonitorRepositoryProvider.java
@@ -3,21 +3,19 @@ package org.palladiosimulator.analyzer.slingshot.monitor.ui;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.analyzer.slingshot.core.extension.ModelProvider;
 import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
-import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 import org.palladiosimulator.monitorrepository.MonitorRepository;
 import org.palladiosimulator.monitorrepository.MonitorRepositoryPackage;
 
 @Singleton
 public class MonitorRepositoryProvider implements ModelProvider<MonitorRepository> {
-	
+
 	private final PCMResourceSetPartitionProvider resourceSet;
-	
+
 	@Inject
 	public MonitorRepositoryProvider(final PCMResourceSetPartitionProvider resourceSet) {
 		this.resourceSet = resourceSet;


### PR DESCRIPTION
what the title says.

not sure whether i always selected the best type for the results, but at least the simuator still runs.

also, my autoformatter is configured to remove unnecessary emptylines and trailing whitespaces, and add missing finals. 
i agologize for the great amount of changes.