### PR TITLE
introduce list probes.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor.utils/src/org/palladiosimulator/analyzer/slingshot/monitor/utils/probes/EventCurrentSimulationTimeProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.utils/src/org/palladiosimulator/analyzer/slingshot/monitor/utils/probes/EventCurrentSimulationTimeProbe.java
@@ -5,7 +5,7 @@ import javax.measure.quantity.Duration;
 import javax.measure.unit.SI;
 
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
-import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventBasedProbe;
+import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventBasedBasicProbe;
 import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventDistinguisher;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 
@@ -13,15 +13,13 @@ import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
  * A standard implementation of a {@link DESEvent}-based probe that takes the
  * current simulation time. The MetricDescription is
  * {@link MetricDescriptionConstants#POINT_IN_TIME_METRIC}.
- * 
+ *
  * @author Julijan Katic
  */
-public final class EventCurrentSimulationTimeProbe extends EventBasedProbe<Double, Duration> {
+public final class EventCurrentSimulationTimeProbe extends EventBasedBasicProbe<Double, Duration> {
 
 	/**
 	 * Constructs a EventCurrentSimulationTimeProbe.
-	 * 
-	 * @param eventType The type of the event.
 	 */
 	public EventCurrentSimulationTimeProbe() {
 		super(MetricDescriptionConstants.POINT_IN_TIME_METRIC);
@@ -29,8 +27,7 @@ public final class EventCurrentSimulationTimeProbe extends EventBasedProbe<Doubl
 
 	/**
 	 * Constructs an EventCurrentSimulationTimeProbe with a custom distinguisher.
-	 * 
-	 * @param eventType     The type of the event.
+	 *
 	 * @param distinguisher The distinguisher that instantiates a
 	 *                      {@link RequestContext}.
 	 */
@@ -44,5 +41,5 @@ public final class EventCurrentSimulationTimeProbe extends EventBasedProbe<Doubl
 		return Measure.valueOf(event.time(), SI.SECOND);
 	}
 
-	
+
 }

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedBasicProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedBasicProbe.java
@@ -1,0 +1,54 @@
+package org.palladiosimulator.analyzer.slingshot.monitor.probes;
+
+import javax.measure.quantity.Quantity;
+
+import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.measurementframework.BasicMeasurement;
+import org.palladiosimulator.metricspec.BaseMetricDescription;
+import org.palladiosimulator.metricspec.MetricDescription;
+import org.palladiosimulator.probeframework.measurement.ProbeMeasurement;
+
+/**
+ * A probe that is {@link DESEvent}-based. Measurements/Probes are taken when
+ * the associated {@link DESEvent} was published.
+ *
+ * @author Julijan Katic
+ *
+ * @param <V> The value type of the measurement.
+ * @param <Q> The quantity type of the measurement.
+ */
+public abstract class EventBasedBasicProbe<V, Q extends Quantity> extends EventBasedProbe<V, Q> {
+
+	/**
+	 * Constructs an event-based probe with
+	 * {@link EventDistinguisher#DEFAULT_DISTINGUISHER}.
+	 *
+	 * @param eventType        The event type to listen to.
+	 * @param metricDesciption A metric description needed by the super-class.
+	 */
+	protected EventBasedBasicProbe(final MetricDescription metricDesciption) {
+		this(metricDesciption, EventDistinguisher.DEFAULT_DISTINGUISHER);
+	}
+
+	/**
+	 * Constructs an event-based probe.
+	 *
+	 * @param eventType        The event type to listen to.
+	 * @param metricDesciption A metric description needed by the super-class.
+	 * @param distinguisher    The distinguisher that is used for creating
+	 *                         {@link RequestContext}s.
+	 */
+	public EventBasedBasicProbe(final MetricDescription metricDescription,
+			final EventDistinguisher distinguisher) {
+		super(metricDescription, distinguisher);
+	}
+
+	@Override
+	protected ProbeMeasurement getProbeMeasurement(final DESEvent event) {
+		final BasicMeasurement<V, Q> resultMeasurement = new BasicMeasurement<>(
+				this.getMeasurement(event), (BaseMetricDescription) this.getMetricDesciption());
+		return new ProbeMeasurement(resultMeasurement, this, this.getDistinguisher().apply(event));
+	}
+
+
+}


### PR DESCRIPTION
### Current Behavior
One class `EventBasedProbe` that takes `BasicMeasurement`s.

### New Behaviour 
make `getProbeMeasurement` in `EventBasedProbe` abstract and add dedicated child classes for list probes and basic probes. 

### Motivation
c.f. https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/issues/14

tl;dr: 
Required for the Active Resource Monitoring. `UnaryCalculator` requires a `MeasurementListMeasureProvider` as `MeasuringValues` when probing. However, the current `EventBasedProbe` only provides `BasicMeasurement`.