### PR TITLE
Include Aggregation

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor.data/src/org/palladiosimulator/analyzer/slingshot/monitor/data/events/ProcessingTypeRevealed.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.data/src/org/palladiosimulator/analyzer/slingshot/monitor/data/events/ProcessingTypeRevealed.java
@@ -1,12 +1,12 @@
 package org.palladiosimulator.analyzer.slingshot.monitor.data.events;
 
-import org.palladiosimulator.analyzer.slingshot.common.events.AbstractEvent;
+import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.ProcessingTypeListener;
 import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
 import org.palladiosimulator.metricspec.MetricDescription;
 import org.palladiosimulator.monitorrepository.ProcessingType;
 
-public final class ProcessingTypeRevealed extends AbstractEvent {
+public final class ProcessingTypeRevealed extends AbstractSimulationEvent {
 
 	private final ProcessingType processingType;
 	private final MetricDescription metricDescription;

--- a/org.palladiosimulator.analyzer.slingshot.monitor.data/src/org/palladiosimulator/analyzer/slingshot/monitor/data/events/modelvisited/MonitorModelVisited.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.data/src/org/palladiosimulator/analyzer/slingshot/monitor/data/events/modelvisited/MonitorModelVisited.java
@@ -15,12 +15,12 @@ import org.palladiosimulator.analyzer.slingshot.monitor.data.events.MonitoringEv
  * between the different event handlers which listen to
  * {@code MonitorModelVisited}, but on a different {@code <MonitorModel>}, the
  * {@link Reified} annotation must be given, for example:
- * 
+ *
  * {@code public ResultEvent<?> onCustomProcessingType(@Reified(CustomProcessingType.class) final MonitorModelVisited<CustomProcessingType> type)}.
- * 
+ *
  * The reason for this is that generic types are erased during run-time, and the
  * information must be given back (in this case, by using an annotation).
- * 
+ *
  * @author Julijan Katic
  *
  * @param <MonitorModel> The monitoring model that has be
@@ -29,7 +29,7 @@ public class MonitorModelVisited<MonitorModel extends EObject> extends ModelVisi
 		implements MonitoringEvent {
 
 	public MonitorModelVisited(final MonitorModel entity) {
-		super(entity);
+		super((Class<MonitorModel>) entity.getClass(), entity, 0.0);
 	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/aggregator/MeasurementsAggregatorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/src/org/palladiosimulator/analyzer/slingshot/monitor/processingtype/aggregator/MeasurementsAggregatorBehavior.java
@@ -12,7 +12,6 @@ import org.palladiosimulator.monitorrepository.VariableSizeAggregation;
 
 
 @OnEvent(when = MonitorModelVisited.class, then = ProcessingTypeRevealed.class, cardinality = EventCardinality.SINGLE)
-@OnEvent(when = MonitorModelVisited.class, then = ProcessingTypeRevealed.class, cardinality = EventCardinality.SINGLE)
 public class MeasurementsAggregatorBehavior implements SimulationBehaviorExtension {
 
 	@Subscribe(reified = FixedSizeAggregation.class)

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/MonitorModule.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/MonitorModule.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.monitor;
 
 import org.palladiosimulator.analyzer.slingshot.core.extension.AbstractSlingshotExtension;
 import org.palladiosimulator.analyzer.slingshot.monitor.calculator.CalculatorFactoryProvider;
+import org.palladiosimulator.analyzer.slingshot.monitor.calculator.DeferredCalculatorMeasurementInitializationBehavior;
 import org.palladiosimulator.analyzer.slingshot.monitor.interpreter.MonitorRepositoryInterpreterBehavior;
 import org.palladiosimulator.analyzer.slingshot.monitor.probes.ProbeFrameworkContextProvider;
 import org.palladiosimulator.analyzer.slingshot.monitor.ui.MonitorRepositoryLaunchConfig;
@@ -9,6 +10,7 @@ import org.palladiosimulator.analyzer.slingshot.monitor.ui.MonitorRepositoryProv
 import org.palladiosimulator.monitorrepository.MonitorRepository;
 import org.palladiosimulator.probeframework.ProbeFrameworkContext;
 import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
+import org.palladiosimulator.probeframework.calculator.IObservableCalculatorRegistry;
 
 public class MonitorModule extends AbstractSlingshotExtension {
 
@@ -16,6 +18,7 @@ public class MonitorModule extends AbstractSlingshotExtension {
 	protected void configure() {
 		// Behaviors
 		install(MonitorRepositoryInterpreterBehavior.class);
+		install(DeferredCalculatorMeasurementInitializationBehavior.class);
 
 		// Launch Config & Model File
 		install(MonitorRepositoryLaunchConfig.class);
@@ -24,6 +27,9 @@ public class MonitorModule extends AbstractSlingshotExtension {
 		// Further objects to be provided
 		install(IGenericCalculatorFactory.class, CalculatorFactoryProvider.class);
 		install(ProbeFrameworkContext.class, ProbeFrameworkContextProvider.class);
+
+		// for deferred
+		install(IObservableCalculatorRegistry.class, ObservableCalculatorRegistryProvider.class);
 	}
 
 

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/ObservableCalculatorRegistryProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/ObservableCalculatorRegistryProvider.java
@@ -1,0 +1,26 @@
+package org.palladiosimulator.analyzer.slingshot.monitor;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.palladiosimulator.probeframework.ProbeFrameworkContext;
+import org.palladiosimulator.probeframework.calculator.IObservableCalculatorRegistry;
+
+
+@Singleton
+public class ObservableCalculatorRegistryProvider implements Provider<IObservableCalculatorRegistry> {
+
+	private final ProbeFrameworkContext probeFrameworkContext;
+
+	@Inject
+	public ObservableCalculatorRegistryProvider(final ProbeFrameworkContext probeFrameworkContext) {
+		this.probeFrameworkContext = probeFrameworkContext;
+	}
+
+	@Override
+	public IObservableCalculatorRegistry get() {
+		return probeFrameworkContext.getCalculatorRegistry();
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/CalculatorFactoryProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/CalculatorFactoryProvider.java
@@ -11,7 +11,7 @@ import org.palladiosimulator.analyzer.slingshot.monitor.recorder.decorator.Monit
 import org.palladiosimulator.analyzer.slingshot.monitor.recorder.decorator.RecorderAttachingCalculatorFactoryDecorator;
 import org.palladiosimulator.probeframework.calculator.ExtensibleCalculatorFactoryDelegatingFactory;
 import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
-
+import org.palladiosimulator.probeframework.calculator.RegisterCalculatorFactoryDecorator;
 
 @Singleton
 public class CalculatorFactoryProvider implements Provider<IGenericCalculatorFactory> {
@@ -19,18 +19,25 @@ public class CalculatorFactoryProvider implements Provider<IGenericCalculatorFac
 	private final SimuComConfig simuComConfig;
 	private final EventBasedMeasurementObserver observer;
 
+	private final IGenericCalculatorFactory factory;
+
 	@Inject
 	public CalculatorFactoryProvider(final SimuComConfig simuComConfig, final EventBasedMeasurementObserver observer) {
 		this.simuComConfig = simuComConfig;
 		this.observer = observer;
+
+		// setup factory here, because registry must be same for all extension.
+		final IGenericCalculatorFactory parentFactory = new ExtensibleCalculatorFactoryDelegatingFactory();
+		final IGenericCalculatorFactory recorderAttachedFactory = new RecorderAttachingCalculatorFactoryDecorator(parentFactory, simuComConfig.getRecorderName(), simuComConfig.getRecorderConfigurationFactory());
+		final IGenericCalculatorFactory monitorAttachedFactory = new MonitoringAttachingCalculatorFactoryDecorator(recorderAttachedFactory, this.observer);
+		final IGenericCalculatorFactory registeringFactory = new RegisterCalculatorFactoryDecorator(
+				monitorAttachedFactory);
+
+		this.factory = registeringFactory;
 	}
 
 	@Override
 	public IGenericCalculatorFactory get() {
-		final IGenericCalculatorFactory parentFactory = new ExtensibleCalculatorFactoryDelegatingFactory();
-		final IGenericCalculatorFactory recorderAttachedFactory = new RecorderAttachingCalculatorFactoryDecorator(parentFactory, simuComConfig.getRecorderName(), simuComConfig.getRecorderConfigurationFactory());
-		final IGenericCalculatorFactory monitorAttachedFactory = new MonitoringAttachingCalculatorFactoryDecorator(recorderAttachedFactory, this.observer);
-
-		return monitorAttachedFactory;
+		return factory;
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/DeferredCalculatorMeasurementInitializationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/calculator/DeferredCalculatorMeasurementInitializationBehavior.java
@@ -86,7 +86,7 @@ public class DeferredCalculatorMeasurementInitializationBehavior implements Simu
 	}
 
 	@Subscribe
-	public void onNewProcessingTypeAvailable(final ProcessingTypeRevealed processingTypeRevealed) {
+	public void onProcessingTypeRevealed(final ProcessingTypeRevealed processingTypeRevealed) {
 		final Optional<Calculator> baseCalculator = this.getBaseCalculator(
 				processingTypeRevealed.getMetricDescription(), processingTypeRevealed.getMeasuringPoint());
 		if (baseCalculator.isPresent()) {


### PR DESCRIPTION
### current behaviour:
The Behaviour to attach the Aggregations was not installed and the Subscription was partially broken.

### new behaviour: 
Aggregator get created and and receive events. 

### overview :
- the behaviour that takes care of attaching aggregation (`DeferredCalculatorMeasurementInitializationBehavior`) wasn't installed () and a provider was missing. 
- `ProcessingTypeRevealed` events weren't deviler because of wrong parent type and some problem with reification.

### misc
this PR is only about including aggregation, not about the correctness of the aggregators.