### PR TITLE
Made the Monitor optional

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorRepositoryInterpreterBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorRepositoryInterpreterBehavior.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.monitor.interpreter;
 
 import javax.inject.Inject;
 
+import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
 import org.palladiosimulator.analyzer.slingshot.core.events.PreSimulationConfigurationStarted;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
@@ -18,10 +19,15 @@ public class MonitorRepositoryInterpreterBehavior implements SimulationBehaviorE
 	private final MonitorRepository monitorRepository;
 
 	@Inject
-	public MonitorRepositoryInterpreterBehavior(final MonitorRepository monitorRepository) {
+	public MonitorRepositoryInterpreterBehavior(@Nullable final MonitorRepository monitorRepository) {
 		this.monitorRepository = monitorRepository;
 	}
 
+	@Override
+	public boolean isActive() {
+		return this.monitorRepository != null;
+	}
+	
 	@Subscribe
 	public Result<MonitoringEvent> onPreSimulationConfigurationStarted(final PreSimulationConfigurationStarted event) {
 		final MonitorModelVisitor visitor = new MonitorModelVisitor();

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/ui/MonitorRepositoryProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/ui/MonitorRepositoryProvider.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.analyzer.slingshot.core.extension.ModelProvider;
 import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
@@ -13,6 +14,8 @@ import org.palladiosimulator.monitorrepository.MonitorRepositoryPackage;
 
 @Singleton
 public class MonitorRepositoryProvider implements ModelProvider<MonitorRepository> {
+	
+	private static final Logger LOGGER = Logger.getLogger(MonitorRepositoryProvider.class);
 
 	private final PCMResourceSetPartitionProvider resourceSet;
 
@@ -25,7 +28,8 @@ public class MonitorRepositoryProvider implements ModelProvider<MonitorRepositor
 	public MonitorRepository get() {
 		final List<EObject> monitors = resourceSet.get().getElement(MonitorRepositoryPackage.eINSTANCE.getMonitorRepository());
 		if (monitors.size() == 0) {
-			throw new IllegalStateException("Monitor not present: List size is 0.");
+			LOGGER.warn("Monitor not present: List size is 0.");
+			return null;
 		}
 		return (MonitorRepository) monitors.get(0);
 	}


### PR DESCRIPTION
Before, it was not possible to start a simulation without a Monitorrepository file. Now, it is optional. If the file was not provided, the behavior extension won't be activated.