### PR TITLE
Ignore Inactive Monitors

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorModelVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorModelVisitor.java
@@ -27,6 +27,10 @@ public class MonitorModelVisitor extends MonitorRepositorySwitch<Set<MonitoringE
 
 	@Override
 	public Set<MonitoringEvent> caseMonitor(final Monitor object) {
+		if (!object.isActivated()) {
+			return Set.of();
+		}
+
 		final int numberMeasurementSpecs = object.getMeasurementSpecifications().size();
 
 		final Set<MonitoringEvent> result = new HashSet<>(numberMeasurementSpecs);


### PR DESCRIPTION
## Current Behaviour
Slingshot always considers all Monitors, active ones as well as inactive ones.
This is at times inconvenients, e.g. if you have a problematic monitor and want to deactivate it. 

## New Bahviour
Slingshot takes the `isActivated` Attribute into consideration and only does monitoring for active Monitors. Inactive Monitors are ignored. 