### PR TITLE
enable EventBasedListProbe to hande (value,time) and (time,value) metric descs.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedListProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedListProbe.java
@@ -77,7 +77,7 @@ public abstract class EventBasedListProbe<V, Q extends Quantity> extends EventBa
 
 		} else {
 			throw new IllegalArgumentException(
-					String.format("Expected MetricSetDescription with at leas one point in time metrib, but got %s.",
+					String.format("Expected MetricSetDescription with at least one point in time metric, but got %s.",
 							metricDescription.getName()));
 		}
 	}

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedListProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedListProbe.java
@@ -1,10 +1,9 @@
 package org.palladiosimulator.analyzer.slingshot.monitor.probes;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.measure.Measure;
-import javax.measure.quantity.Duration;
 import javax.measure.quantity.Quantity;
 import javax.measure.unit.SI;
 
@@ -15,6 +14,7 @@ import org.palladiosimulator.measurementframework.measureprovider.MeasurementLis
 import org.palladiosimulator.metricspec.BaseMetricDescription;
 import org.palladiosimulator.metricspec.MetricDescription;
 import org.palladiosimulator.metricspec.MetricSetDescription;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.probeframework.measurement.ProbeMeasurement;
 
 /**
@@ -26,12 +26,17 @@ import org.palladiosimulator.probeframework.measurement.ProbeMeasurement;
  *
  * Beware: This probe requires a {@link MetricSetDescription}.
  *
+ * Beware: MetricSetDescriptions are define as (time, value)-pair or as (value, time)-pair. This Probe makes sure to keep thing in the correct order.
+ *
  * @author Sarah Stieß
  *
  * @param <V> The value type of the measurement.
  * @param <Q> The quantity type of the measurement.
  */
 public abstract class EventBasedListProbe<V, Q extends Quantity> extends EventBasedProbe<V, Q> {
+
+	Function<DESEvent, MeasuringValue> firstvalue;
+	Function<DESEvent, MeasuringValue> secondvalue;
 
 	/**
 	 * Constructs an event-based probe with
@@ -40,13 +45,7 @@ public abstract class EventBasedListProbe<V, Q extends Quantity> extends EventBa
 	 * @param metricDescription A metric description needed by the super-class.
 	 */
 	protected EventBasedListProbe(final MetricDescription metricDescription) {
-		super(metricDescription);
-
-		if (!(metricDescription instanceof MetricSetDescription)) {
-			throw new IllegalArgumentException(String.format(
-					"Illegal Metric Decription for Unary Calculator. Got %s %s but require a MetricSetDescription.",
-					metricDescription.getClass().getSimpleName(), metricDescription.getName()));
-		}
+		this(metricDescription, EventDistinguisher.DEFAULT_DISTINGUISHER);
 	}
 
 	/**
@@ -56,37 +55,61 @@ public abstract class EventBasedListProbe<V, Q extends Quantity> extends EventBa
 	 * @param distinguisher     The distinguisher that is used for creating
 	 *                          {@link RequestContext}s.
 	 */
-	public EventBasedListProbe(final MetricDescription metricDescription,
-			final EventDistinguisher distinguisher) {
+	public EventBasedListProbe(final MetricDescription metricDescription, final EventDistinguisher distinguisher) {
 		super(metricDescription, distinguisher);
+
+		if (!(metricDescription instanceof MetricSetDescription)) {
+			throw new IllegalArgumentException(String.format(
+					"Illegal Metric Decription for Unary Calculator. Got %s %s but require a MetricSetDescription.",
+					metricDescription.getClass().getSimpleName(), metricDescription.getName()));
+		}
+
+		final List<MetricDescription> descriptions = ((MetricSetDescription) this.getMetricDesciption())
+				.getSubsumedMetrics();
+
+		if (descriptions.get(0).equals(MetricDescriptionConstants.POINT_IN_TIME_METRIC)) {
+			firstvalue = this::getTime;
+			secondvalue = (final DESEvent e) -> this.getValue(e, (BaseMetricDescription) descriptions.get(1));
+
+		} else if (descriptions.get(1).equals(MetricDescriptionConstants.POINT_IN_TIME_METRIC)) {
+			secondvalue = this::getTime;
+			firstvalue = (final DESEvent e) -> this.getValue(e, (BaseMetricDescription) descriptions.get(0));
+
+		} else {
+			throw new IllegalArgumentException(
+					String.format("Expected MetricSetDescription with at leas one point in time metrib, but got %s.",
+							metricDescription.getName()));
+		}
 	}
 
-	private final BaseMetricDescription getTimeMetricDescription() {
-		return (BaseMetricDescription) ((MetricSetDescription) this.getMetricDesciption()).getSubsumedMetrics().get(0);
+	/**
+	 * Extract measuring value for the point in time of the probe measurement.
+	 *
+	 * @param event Event to extract time from.
+	 * @return time for the probe measurement.
+	 */
+	private MeasuringValue getTime(final DESEvent event) {
+		return new BasicMeasurement<>(Measure.valueOf(event.time(), SI.SECOND),
+				MetricDescriptionConstants.POINT_IN_TIME_METRIC)
+						.getMeasuringValueForMetric(MetricDescriptionConstants.POINT_IN_TIME_METRIC);
 	}
 
-	private final BaseMetricDescription getValueMetricDescription() {
-		return (BaseMetricDescription) ((MetricSetDescription) this.getMetricDesciption()).getSubsumedMetrics().get(1);
-	}
-
-	public Measure<Double, Duration> getTime(final DESEvent event) {
-		return Measure.valueOf(event.time(), SI.SECOND);
+	/**
+	 *
+	 * Extract measuring value for the value of the probe measurement
+	 *
+	 * @param event Event to extract the value from.
+	 * @param desc  Metric description of the value to be extracted.
+	 * @return value for the probe measurement.
+	 */
+	private MeasuringValue getValue(final DESEvent event, final BaseMetricDescription desc) {
+		return new BasicMeasurement<>(this.getMeasurement(event), desc).getMeasuringValueForMetric(desc);
 	}
 
 	@Override
 	protected ProbeMeasurement getProbeMeasurement(final DESEvent event) {
-		final List<MeasuringValue> list = new ArrayList<>(2);
-
-		/* TIME */
-		final MeasuringValue pointInTimeMeasurement = new BasicMeasurement<>(this.getTime(event),
-				this.getTimeMetricDescription()).getMeasuringValueForMetric(this.getTimeMetricDescription());
-		list.add(pointInTimeMeasurement);
-		/* VALUE */
-		final MeasuringValue valueMeasurement = new BasicMeasurement<>(this.getMeasurement(event),
-				this.getValueMetricDescription()).getMeasuringValueForMetric(this.getValueMetricDescription());
-		list.add(valueMeasurement);
-
-		final MeasurementListMeasureProvider resultMeasurement = new MeasurementListMeasureProvider(list);
+		final MeasurementListMeasureProvider resultMeasurement = new MeasurementListMeasureProvider(
+				List.of(firstvalue.apply(event), secondvalue.apply(event)));
 		return new ProbeMeasurement(resultMeasurement, this, this.getDistinguisher().apply(event));
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedListProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/probes/EventBasedListProbe.java
@@ -35,8 +35,8 @@ import org.palladiosimulator.probeframework.measurement.ProbeMeasurement;
  */
 public abstract class EventBasedListProbe<V, Q extends Quantity> extends EventBasedProbe<V, Q> {
 
-	Function<DESEvent, MeasuringValue> firstvalue;
-	Function<DESEvent, MeasuringValue> secondvalue;
+	private final Function<DESEvent, MeasuringValue> firstvalue;
+	private final Function<DESEvent, MeasuringValue> secondvalue;
 
 	/**
 	 * Constructs an event-based probe with


### PR DESCRIPTION
There are apparently multiple MetricSetDescriptions that use  (value, time) instead of  (time, value).
Among others the Number Of Resources, for which we need a monitor (c.f. PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core#41)

## Current behaviour
EventBasedListProbe only handles (time,value)  pairs correctly, all other throw exceptions. 


## New behaviour
EventBasedListProbe can handle bothe  (time,value) and  (value, time) pairs without  exceptions. 