### PR TITLE
Beware the new monitors

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.monitor/META-INF/MANIFEST.MF
@@ -16,5 +16,7 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.recorderframework;bundle-version="5.1.0";visibility:=reexport,
  org.palladiosimulator.analyzer.slingshot.monitor.data;bundle-version="1.0.0",
  org.palladiosimulator.edp2.util,
- de.uka.ipd.sdq.simucomframework
+ de.uka.ipd.sdq.simucomframework,
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
+ org.palladiosimulator.pcm.edp2.measuringpoint
 Export-Package: org.palladiosimulator.analyzer.slingshot.monitor.probes


### PR DESCRIPTION
With this PR, for new resource containers a new monitor will be created (the creation process is done by the SPD interpreter). Here, we interpret these new changes and register them.