### PR TITLE
API Change of Core: Relying on the new Model Changes from Core

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor/META-INF/MANIFEST.MF
@@ -16,6 +16,5 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.monitor.data;bundle-version="1.0.0",
  org.palladiosimulator.edp2.util,
  de.uka.ipd.sdq.simucomframework,
- org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
  org.palladiosimulator.pcm.edp2.measuringpoint
 Export-Package: org.palladiosimulator.analyzer.slingshot.monitor.probes

--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorRepositoryInterpreterBehavior.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor/src/org/palladiosimulator/analyzer/slingshot/monitor/interpreter/MonitorRepositoryInterpreterBehavior.java
@@ -6,9 +6,9 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.eclipse.emf.ecore.EObject;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.MonitorChange;
 import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.ModelAdjusted;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.MonitorChange;
 import org.palladiosimulator.analyzer.slingshot.core.events.PreSimulationConfigurationStarted;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;


### PR DESCRIPTION
Core has changed its API by providing a new set of events which previously resided in SPD as indicated by this https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot/pull/26 (requires the merge)
 