### PR TITLE
remove fixed version numbers in MANIFEST

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor.data/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor.data/META-INF/MANIFEST.MF
@@ -9,6 +9,6 @@ Export-Package: org.palladiosimulator.analyzer.slingshot.monitor.data.entities,
 Require-Bundle: org.palladiosimulator.measurementframework;visibility:=reexport,
  org.palladiosimulator.probeframework,
  org.palladiosimulator.monitorrepository,
- org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.0.0"
+ org.palladiosimulator.analyzer.slingshot.core
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.monitor.data

--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.monitor.processing
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.monitor.processingtype.aggregator
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.palladiosimulator.analyzer.slingshot.monitor.data;bundle-version="1.0.0",
+Require-Bundle: org.palladiosimulator.analyzer.slingshot.monitor.data,
  org.palladiosimulator.edp2.util,
  org.palladiosimulator.monitorrepository,
- org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.0.0"
+ org.palladiosimulator.analyzer.slingshot.core

--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.feedthrough/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor.processingtype.feedthrough/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.monitor.processi
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.palladiosimulator.analyzer.slingshot.monitor.data,
  org.palladiosimulator.monitorrepository,
- org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.0.0"
+ org.palladiosimulator.analyzer.slingshot.core

--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor.utils/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor.utils/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.monitor.utils
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.monitor.utils
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.common;bundle-version="1.0.0",
+Require-Bundle: org.palladiosimulator.analyzer.slingshot.monitor,
+ org.palladiosimulator.analyzer.slingshot.common,
  org.palladiosimulator.metricspec
 Export-Package: org.palladiosimulator.analyzer.slingshot.monitor.utils.probes

--- a/bundles/org.palladiosimulator.analyzer.slingshot.monitor/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.monitor/META-INF/MANIFEST.MF
@@ -5,15 +5,15 @@ Bundle-SymbolicName: org.palladiosimulator.analyzer.slingshot.monitor;singleton:
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.analyzer.slingshot.monitor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.ui.events;bundle-version="1.0.0",
+Require-Bundle: org.palladiosimulator.analyzer.slingshot.core,
+ org.palladiosimulator.analyzer.slingshot.ui.events,
  org.palladiosimulator.monitorrepository;bundle-version="5.1.0",
- org.palladiosimulator.analyzer.slingshot.workflow.events;bundle-version="1.0.0",
+ org.palladiosimulator.analyzer.slingshot.workflow.events,
  org.palladiosimulator.analyzer.workflow,
  de.uka.ipd.sdq.workflow.mdsd.blackboard;bundle-version="5.1.0",
  org.palladiosimulator.probeframework;bundle-version="5.1.0";visibility:=reexport,
  org.palladiosimulator.recorderframework;bundle-version="5.1.0";visibility:=reexport,
- org.palladiosimulator.analyzer.slingshot.monitor.data;bundle-version="1.0.0",
+ org.palladiosimulator.analyzer.slingshot.monitor.data,
  org.palladiosimulator.edp2.util,
  de.uka.ipd.sdq.simucomframework,
  org.palladiosimulator.pcm.edp2.measuringpoint


### PR DESCRIPTION
For some dependencies to other Slingshot components, their verison was fixed to `1.0.0`.

When attempting to export and installable feature from the slingshot, and installing the feature, this cause an error because of missing depenencies / mismatched dependencie versions.

I now removed all fixed versions that caused problems. For my, export an installation works now.